### PR TITLE
Slash commands (Fix #13)

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+	"useTabs": true,
+	"singleQuote": false,
+	"semi": false
+}

--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # CTF Discord Bot
 
-Requires Node v14.
+Requires Node v16.9.0
 
 License: MIT
 
 ## Features
 
-* Show rank stats embed for a player.
-  * `!rank` - Stats for player with the Discord user's username or nickname.
-  * `!rank username` - Stats for player `username`.
-  * `!help` - Help.
-* Posts leaderboard to a channel, editing existing messages.
+- Show rank stats embed for a player.
+  - `/rank` - Stats for player with the Discord user's username or nickname.
+  - `/rank username` - Stats for player `username`.
+  - `/x` - Send message on the staff channel (See [this](https://github.com/MT-CTF/servermods/blob/master/server_chat/init.lua#L77)).
+  - `/mute user` - Mute Discord member.
+  - `/unmute user` - Unmute Discord member.
+  - `/leaders` - Redirect to the leaderboard channel.
+- Posts leaderboard to a channel, editing existing messages.
 
 ## Usage
 
-* Create Discord bot and application using the [Discord Developer Portal](https://discord.com/developers/applications/),
+- Create Discord bot and application using the [Discord Developer Portal](https://discord.com/developers/applications/),
   as shown in [this guide](https://discordjs.guide/preparations/setting-up-a-bot-application.html#creating-your-bot).
-* Invite the Discord bot to the desired server, as shown in
+- Invite the Discord bot to the desired server, as shown in
   [this guide](https://discordjs.guide/preparations/adding-your-bot-to-servers.html#bot-invite-links).
-* Install dependencies: `npm install`.
-* Run with environment variables: `RANKINGS_CHANNEL=id TOKEN=discord_token npm start`
-  * `RANKINGS_CHANNEL` - Channel ID for the leaderboard.
-  * `TOKEN` - Discord bot token, get from bot page in Discord Developer Portal.
-
-## Other
-
-You can grab messages sent with !x via Minetest. See https://github.com/MT-CTF/servermods/blob/master/server_chat/init.lua#L77 for an example
+- Install dependencies: `npm install`.
+- Run with environment variables: `GUILD_ID=guild_id RANKINGS_CHANNEL=id TOKEN=discord_token npm start`
+  - `GUILD_ID` - Guild ID used for slash commands.
+  - `RANKINGS_CHANNEL` - Channel ID for the leaderboard.
+  - `TOKEN` - Discord bot token, get from bot page in Discord Developer Portal.

--- a/config.json.exemple
+++ b/config.json.exemple
@@ -1,0 +1,4 @@
+{
+	"token": "Bot ABCDEFGHIJKLMNOPQRSTUVWXYZ.1234567890",
+	"guildid": "the id of you server",
+}

--- a/config.json.exemple
+++ b/config.json.exemple
@@ -1,4 +1,0 @@
-{
-	"token": "Bot ABCDEFGHIJKLMNOPQRSTUVWXYZ.1234567890",
-	"guildid": "the id of you server",
-}

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ discordClient.on("interactionCreate", async(interaction) => {
 			})
 		}
 		let muterole = interaction.guild.roles.cache.find(role => role.name === "Muterated");
-		muted_member.roles.add(muterole.id);
+		await muted_member.roles.add(muterole.id);
 		interaction.reply({
 			embeds: [
 				new Discord.MessageEmbed()

--- a/index.js
+++ b/index.js
@@ -185,57 +185,6 @@ function formatRanking(stats, mode) {
 		.setTimestamp()
 }
 
-function handleRankRequest(message, command, args) {
-	if (!statsMap) {
-		message.channel.send("Please wait, stats are still loading...")
-		return
-	}
-
-	const username = message.author.username.trim()
-	const nickname = message.member.nickname
-		? message.member.nickname.trim()
-		: username
-	const name = args.length > 0 ? args[0].trim() : nickname
-
-	let playerStats = []
-
-	for (const mode of [...statsMap.keys()].sort()) {
-		let stat = statsMap.get(mode).get(name.toLowerCase())
-		if (!stat && args.length == 0) {
-			stat = statsMap.get(mode).get(username.toLowerCase())
-		}
-		if (stat) {
-			playerStats.push([stat, mode])
-		}
-	}
-
-	if (playerStats.length > 0) {
-		for (const [stat, mode] of playerStats) {
-			message.channel.send(formatRanking(stat, mode))
-		}
-
-		if (
-			args.length > 0 &&
-			(name.toLowerCase() == nickname.toLowerCase() ||
-				name.toLowerCase() == username.toLowerCase())
-		) {
-			message.channel.send(`_pst: you can just use \`!${command}\`_`)
-		}
-	} else {
-		if (args.length > 0) {
-			message.channel.send(`Unable to find user ${name}`)
-		} else if (username.toLowerCase() != nickname.toLowerCase()) {
-			message.channel.send(
-				`Unable to find ${nickname} or ${username}, please provide username explicitly like so: \`!rank username\``
-			)
-		} else {
-			message.channel.send(
-				`Unable to find ${nickname}, please provide username explicitly like so: \`!rank username\``
-			)
-		}
-	}
-}
-
 const error_embed_admin_mute = new Discord.EmbedBuilder()
 	.setColor(Discord.Colors.Red)
 	.setDescription("The user you are trying to mute is a staff member!")

--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 const Discord = require("discord.js");
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
 const discordClient = new Discord.Client();
-const redisClient = require("redis").createClient();
+
+//TODO: enable redis server again
+
+//const redisClient = require("redis").createClient();
+
+const guildId = process.env.GUILD_ID;
 const rankingsChannel = process.env.RANKINGS_CHANNEL;
 const prefix = "!";
 
@@ -249,10 +256,10 @@ discordClient.on("message", message => {
 
 async function main() {
 	await discordClient.login(process.env.TOKEN);
-	await redisClient.connect();
+	///await redisClient.connect();
 
-	await updateRankings();
-	setInterval(updateRankings, 60000);
+	//await updateRankings();
+	//setInterval(updateRankings, 60000);
 
 	var http = require('http');
 	http.createServer(function (req, res) {

--- a/index.js
+++ b/index.js
@@ -73,12 +73,15 @@ async function updateRankingsChannel(statsList) {
 	const messages = await channel.messages.fetch({ limit: rankings.length })
 	if (messages.size < rankings.length) {
 		for (var i = 0; i < rankings.length; ++i) {
-			await channel.send(rankings[i])
+			await channel.send({ embeds: [rankings[i]], ephemeral: false })
 		}
 	} else {
 		let it = messages.values()
 		for (var i = 0; i < rankings.length; ++i) {
-			await it.next().value.edit(rankings[rankings.length - i - 1])
+			await it.next().value.edit({
+				embeds: [rankings[rankings.length - i - 1]],
+				ephemeral: false,
+			})
 		}
 	}
 }
@@ -125,7 +128,7 @@ async function updateRankings() {
 		}
 	}
 
-	//await updateRankingsChannel(statsList)
+	await updateRankingsChannel(statsList)
 	statsPlayers.sort()
 }
 

--- a/index.js
+++ b/index.js
@@ -196,8 +196,66 @@ function handleRankRequest(message, command, args) {
 	}
 }
 
+const error_embed = new Discord.MessageEmbed()
+	.setColor("RED")
+	.setDescription("You dont have the permission to run this command.")
+
+// commands definition
+
+const commands = [];
+
+//fixme
+commands.push(new SlashCommandBuilder()
+	.setName("rank")
+	.setDescription("Shows ingame rankings")
+);
+
+commands.push(new SlashCommandBuilder()
+	.setName("x")
+	.setDescription("Send messages on staff channel")
+	.addStringOption(option => option
+		.setName('message')
+		.setDescription('Enter message')
+		.setRequired(true)
+	)
+);
+
 discordClient.on("ready", () => {
 	console.log(`Logged in as ${discordClient.user.tag}!`);
+
+	const guild = client.guilds.resolve(guildId);
+
+	//push commands to server
+	guild.commands.set(commands).catch(console.log);
+});
+
+discordClient.on("interactionCreate", async(interaction) => {
+	if (!interaction.isCommand()) {
+		return
+	}
+
+	const {commandName, member, memberPermissions, options} = interaction
+
+	//handle commands
+	if (commandName === "x") {
+		if (!memberPermissions.has("KICK_MEMBERS", true)) {
+			return interaction.reply({
+				embeds: [error_embed],
+				ephemeral: true,
+			})
+		}
+
+		staffMessages.push(`<${member.user.username}@Discord> ${options.getString("message")}`);
+
+		interaction.reply({
+			embeds: [
+				new Discord.MessageEmbed()
+					.setColor("BLUE")
+					.setDescription(`**${member.user.username}**: ${options.getString("message")}`)
+			],
+			ephemeral: false,
+		})
+	}
 });
 
 discordClient.on("message", message => {

--- a/index.js
+++ b/index.js
@@ -84,7 +84,6 @@ async function updateRankingsChannel(statsList) {
 }
 
 async function updateRankings() {
-	console.log("updateRankings called")
 	let statsList = new Map()
 	statsPlayers = []
 	for (const key of await redisClient.keys("ctf_mode_*")) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
 const Discord = require("discord.js");
 const { SlashCommandBuilder } = require('@discordjs/builders');
 
-const discordClient = new Discord.Client();
+const discordClient = new Discord.Client({
+	intents: [
+		Discord.Intents.FLAGS.GUILDS,
+		Discord.Intents.FLAGS.GUILD_MESSAGES,
+		Discord.Intents.FLAGS.GUILD_INTEGRATIONS,
+	]
+});
 
 //TODO: enable redis server again
 

--- a/index.js
+++ b/index.js
@@ -220,6 +220,26 @@ commands.push(new SlashCommandBuilder()
 	)
 );
 
+commands.push(new SlashCommandBuilder()
+	.setName('mute')
+	.setDescription('Mutes a user')
+	.addUserOption(option => option
+		.setName("user")
+		.setDescription("User to mute")
+		.setRequired(true)
+	)
+);
+
+commands.push(new SlashCommandBuilder()
+	.setName('unmute')
+	.setDescription('Unmutes a user')
+	.addUserOption(option => option
+		.setName("user")
+		.setDescription("User to unmute")
+		.setRequired(true)
+	)
+);
+
 discordClient.on("ready", () => {
 	console.log(`Logged in as ${discordClient.user.tag}!`);
 
@@ -252,6 +272,24 @@ discordClient.on("interactionCreate", async(interaction) => {
 				new Discord.MessageEmbed()
 					.setColor("BLUE")
 					.setDescription(`**${member.user.username}**: ${options.getString("message")}`)
+			],
+			ephemeral: false,
+		})
+	} else if (commandName === "mute") {
+		const muted_member = options.getMember("user");
+		if (!memberPermissions.has("KICK_MEMBERS", true)) {
+			return interaction.reply({
+				embeds: [error_embed],
+				ephemeral: true,
+			})
+		}
+		let muterole = interaction.guild.roles.cache.find(role => role.name === "Muterated");
+		muted_member.roles.add(muterole.id);
+		interaction.reply({
+			embeds: [
+				new Discord.MessageEmbed()
+					.setColor("BLUE")
+					.setDescription(`**${muted_member.user.username}** has been muted.`)
 			],
 			ephemeral: false,
 		})

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const discordClient = new Discord.Client();
 
 const guildId = process.env.GUILD_ID;
 const rankingsChannel = process.env.RANKINGS_CHANNEL;
+const token = process.env.TOKEN;
+
 const prefix = "!";
 
 let staffMessages = []
@@ -255,7 +257,7 @@ discordClient.on("message", message => {
 });
 
 async function main() {
-	await discordClient.login(process.env.TOKEN);
+	await discordClient.login(token);
 	///await redisClient.connect();
 
 	//await updateRankings();

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const discordClient = new Discord.Client({
 	],
 })
 
-const redisClient = redis.createClient({ url: "redis://localhost:6380" })
+const redisClient = redis.createClient()
 
 const guildId = process.env.GUILD_ID
 const rankingsChannel = process.env.RANKINGS_CHANNEL

--- a/index.js
+++ b/index.js
@@ -296,6 +296,7 @@ discordClient.on("interactionCreate", async(interaction) => {
 	}
 });
 
+/*
 discordClient.on("message", message => {
 	if (message.content[0] != prefix) {
 		return;
@@ -357,6 +358,7 @@ discordClient.on("message", message => {
 		message.react('☑️');
 	}
 });
+*/
 
 async function main() {
 	await discordClient.login(token);

--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ commands.push(new SlashCommandBuilder()
 discordClient.on("ready", () => {
 	console.log(`Logged in as ${discordClient.user.tag}!`);
 
-	const guild = client.guilds.resolve(guildId);
+	const guild = discordClient.guilds.resolve(guildId);
 
 	//push commands to server
 	guild.commands.set(commands).catch(console.log);

--- a/index.js
+++ b/index.js
@@ -17,8 +17,6 @@ const guildId = process.env.GUILD_ID
 const rankingsChannel = process.env.RANKINGS_CHANNEL
 const token = process.env.TOKEN
 
-const prefix = "!"
-
 let staffMessages = []
 let statsMap = null
 let statsPlayers = null

--- a/index.js
+++ b/index.js
@@ -457,8 +457,8 @@ async function main() {
 	await updateRankings()
 	setInterval(updateRankings, 6000)
 
-	http
-		.createServer(function (req, res) {
+	// prettier-ignore
+	http.createServer(function (req, res) {
 			if (req.method == "GET" && staffMessages.length > 0) {
 				res.writeHead(200, { "Content-Type": "text/plain" })
 				console.log("Relaying staff messages: " + staffMessages.join("-|-"))

--- a/package.json
+++ b/package.json
@@ -1,25 +1,26 @@
 {
-  "name": "ctf-discord-bot",
-  "version": "0.1.0",
-  "description": "A bot to manage roles and such on Discord",
-  "main": "index.js",
-  "scripts": {
-    "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/MT-CTF/ctf-discord-bot.git"
-  },
-  "author": "rubenwardy",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/MT-CTF/ctf-discord-bot/issues"
-  },
-  "homepage": "https://github.com/MT-CTF/ctf-discord-bot#readme",
-  "dependencies": {
-    "discord.js": "^13.5.0",
-	"@discordjs/builders": "^0.11.0",
-    "redis": "^4.0.0-rc.4"
-  }
+	"name": "ctf-discord-bot",
+	"version": "0.1.0",
+	"description": "A bot to manage roles and such on Discord",
+	"type": "module",
+	"main": "index.js",
+	"scripts": {
+		"start": "node index.js",
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/MT-CTF/ctf-discord-bot.git"
+	},
+	"author": "rubenwardy",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/MT-CTF/ctf-discord-bot/issues"
+	},
+	"homepage": "https://github.com/MT-CTF/ctf-discord-bot#readme",
+	"dependencies": {
+		"discord.js": "^14.3.0",
+		"dotenv": "^16.0.1",
+		"redis": "^4.0.0-rc.4"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "homepage": "https://github.com/MT-CTF/ctf-discord-bot#readme",
   "dependencies": {
-    "discord.js": "^12.3.1",
+    "discord.js": "^13.5.0",
+	"@discordjs/builders": "^0.11.0",
     "redis": "^4.0.0-rc.4"
   }
 }


### PR DESCRIPTION
- [x] Slash commands instead of normal ones
    - [x] `/mute`
    - [x] `/unmute`
    - [x] `/x`
    - [x] `/rank` (with autocomplete)
    - [x] `/leaders`
- [x] Update to discord.js 14
- [x] Switch from CJS to ESM
- [x] Commands privilege check at the Discord level
- [x] More Embeds
- [x] Fix broken leaderboard 
- [x] README

Fix https://github.com/MT-CTF/ctf-discord-bot/issues/13

**MERGE AS A SINGLE COMMIT WHEN READY**